### PR TITLE
Fix quotation

### DIFF
--- a/topik/pemrograman-dasar-cpp/04-penunjang-pemrograman-dasar/pemrograman-dasar-cpp_04-penunjang-pemrograman-dasar.tex
+++ b/topik/pemrograman-dasar-cpp/04-penunjang-pemrograman-dasar/pemrograman-dasar-cpp_04-penunjang-pemrograman-dasar.tex
@@ -118,8 +118,8 @@ Mampu memahami pesan kesalahan yang disampaikan dapat membantu kita memperbaiki 
     <nama berkas>:<nomor baris>:<nomor kolom>: error: <jenis error>
   \end{lstlisting}
   Contoh:
-  \begin{lstlisting}
-    tes.cpp:18:34: error: ‘hasil’ was not declared in this scope
+  \begin{lstlisting}[language={}]
+    tes.cpp:18:34: error: `hasil' was not declared in this scope
   \end{lstlisting}
   \item Artinya pada berkas tes.cpp, baris 4, kolom 13, terdapat kesalahan berupa: sebuah variabel bernama "nilai" tidak ditemukan. Untuk memperbaikinya, "nilai" harus dideklarasikan terlebih dahulu.
 \end{itemize}


### PR DESCRIPTION
The character `’` is not an UTF-8 character and may throw an `Invalid UTF-8 byte sequence` error for some versions of `pdflatex`.

Even though it was built successfully, currently the quotation is not rendered (see slide 10 of https://github.com/ia-toki/training-gate-id-pdf/blob/master/pemrograman-dasar-cpp_04-penunjang-pemrograman-dasar.pdf)