### PR TITLE
Rearrange while loop code to its for loop equivalence

### DIFF
--- a/topik/pemrograman-dasar-cpp/07-perulangan-lanjut/pemrograman-dasar-cpp_07-perulangan-lanjut.tex
+++ b/topik/pemrograman-dasar-cpp/07-perulangan-lanjut/pemrograman-dasar-cpp_07-perulangan-lanjut.tex
@@ -107,8 +107,8 @@ int main() {
       printf("*");
       j++;
     }
-    i++;
     printf("\n");
+    i++;
   }
 }
 \end{lstlisting}


### PR DESCRIPTION
Kecuali memang disengaja*, lebih baik while-loop ditulis semirip mungkin dengan versi for-loop nya agar sesuai dengan materi di bab 6 slide 16.

https://github.com/ia-toki/training-gate-id/blob/20f7d9937fa2ce577e6a587339892970cdbd5a80/topik/pemrograman-dasar-cpp/06-perulangan/pemrograman-dasar-cpp_06-perulangan.tex#L241-L264

*) misal untuk menunjukkan bahwa meskipun susunan kode while-loop tidak ekuivalen dengan contoh for-loop sebelumnya, dalam contoh kasus ini tetap benar karena perintah `printf()` tidak menggunakan variable `i`.